### PR TITLE
Cholesky Decomposition - Modifications(corrected)

### DIFF
--- a/src/main/java/mikera/matrixx/algo/decompose/chol/impl/Cholesky.java
+++ b/src/main/java/mikera/matrixx/algo/decompose/chol/impl/Cholesky.java
@@ -20,9 +20,6 @@ package mikera.matrixx.algo.decompose.chol.impl;
 
 import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrix;
-import mikera.matrixx.algo.decompose.chol.ICholesky;
-
-
 
 /**
  * This is an implementation of Cholesky that processes internal submatrices as blocks.  This is
@@ -63,22 +60,40 @@ public class Cholesky extends CholeskyCommon {
         this.blockWidth = BLOCK_WIDTH;
 
     }
-
+    
     /**
-     * Declares additional internal data structures.
+     * <p>
+     * Performs Choleksy decomposition on the provided matrix.
+     * </p>
+     *
+     * <p>
+     * If the matrix is not positive definite then this function will return
+     * null since it can't complete its computations.  Not all errors will be
+     * found.  This is an efficient way to check for positive definiteness.
+     * </p>
+     * @param mat A symmetric positive definite matrix
+     * @return CholeskyResult if decomposition is successful, null otherwise
      */
     @Override
-    public void setExpectedMaxSize( int numRows , int numCols ) {
-        super.setExpectedMaxSize(numRows,numCols);
+    public CholeskyResult decompose( AMatrix mat ) {
+    	if( mat.rowCount() != mat.columnCount() ) {
+            throw new IllegalArgumentException("Must be a square matrix.");
+        }
 
-        // if the matrix that is being decomposed is smaller than the block we really don't
-        // see the B matrix.
-        if( numRows < blockWidth)
-            B = Matrix.create(0,0);
-        else
-            B = Matrix.create(blockWidth,maxWidth);
+        n = mat.rowCount();
+        this.vv = new double[n];
+        T = mat.toMatrix();
+        t = T.data;
+        
+        if(mat.rowCount() < blockWidth) {
+    		B = Matrix.create(0,0);
+    	}
+    	else {
+    		B = Matrix.create(blockWidth,n);
+    	}
+    	chol = new CholeskyHelper(blockWidth);
 
-        chol = new CholeskyHelper(blockWidth);
+        return decomposeLower();
     }
 
     /**
@@ -88,13 +103,13 @@ public class Cholesky extends CholeskyCommon {
      *
      * <p>
      * If the matrix is not positive definite then this function will return
-     * false since it can't complete its computations.  Not all errors will be
+     * null since it can't complete its computations.  Not all errors will be
      * found.
      * </p>
-     * @return True if it was able to finish the decomposition.
+     * @return CholeskyResult if decomposition is successful, null otherwise
      */
     @Override
-    protected ICholesky decomposeLower() {
+    protected CholeskyResult decomposeLower() {
 
         if( n < blockWidth)
 //            B.reshape(0,0, false);
@@ -150,7 +165,7 @@ public class Cholesky extends CholeskyCommon {
             }
         }
 
-        return this;
+        return new CholeskyResult(T);
     }
     
     /**

--- a/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyCommon.java
+++ b/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyCommon.java
@@ -21,7 +21,6 @@ package mikera.matrixx.algo.decompose.chol.impl;
 
 import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrix;
-import mikera.matrixx.algo.decompose.chol.ICholesky;
 
 /**
  *
@@ -46,10 +45,7 @@ import mikera.matrixx.algo.decompose.chol.ICholesky;
  *
  * @author Peter Abeles
  */
-public abstract class CholeskyCommon implements ICholesky {
-
-    // it can decompose a matrix up to this width
-    protected int maxWidth=-1;
+public abstract class CholeskyCommon {
 
     // width and height of the matrix
     protected int n;
@@ -68,16 +64,6 @@ public abstract class CholeskyCommon implements ICholesky {
     public CholeskyCommon() {
     }
 
-    public void setExpectedMaxSize( int numRows , int numCols ) {
-        if( numRows != numCols ) {
-            throw new IllegalArgumentException("Can only decompose square matrices");
-        }
-
-        this.maxWidth = numCols;
-
-        this.vv = new double[maxWidth];
-    }
-
     /**
      * <p>
      * Performs Choleksy decomposition on the provided matrix.
@@ -88,18 +74,16 @@ public abstract class CholeskyCommon implements ICholesky {
      * null since it can't complete its computations.  Not all errors will be
      * found.  This is an efficient way to check for positive definiteness.
      * </p>
-     * @param mat A symmetric positive definite matrix with n <= widthMax.
-     * @return True if it was able to finish the decomposition.
+     * @param mat A symmetric positive definite matrix.
+     * @return CholeskyResult if decomposition is successful, null otherwise.
      */
-    public ICholesky decompose( AMatrix mat ) {
-        if( mat.rowCount() > maxWidth ) {
-            setExpectedMaxSize(mat.rowCount(),mat.columnCount());
-        } else if( mat.rowCount() != mat.columnCount() ) {
+    public CholeskyResult decompose( AMatrix mat ) {
+        if( mat.rowCount() != mat.columnCount() ) {
             throw new IllegalArgumentException("Must be a square matrix.");
         }
 
         n = mat.rowCount();
-
+        this.vv = new double[n];
         T = mat.toMatrix();
         t = T.data;
 
@@ -109,25 +93,7 @@ public abstract class CholeskyCommon implements ICholesky {
     /**
      * Performs an lower triangular decomposition.
      */
-    protected abstract ICholesky decomposeLower();
-
-    /**
-     * Returns the lower triangular matrix from the decomposition.
-     *
-     * @return A lower triangular matrix.
-     */
-    public AMatrix getL() {
-    	return T;
-    }
-
-    /**
-     * Returns the upper triangular matrix from the decomposition.
-     *
-     * @return An upper triangular matrix.
-     */
-    public AMatrix getU() {
-        return T.getTranspose();
-    }
+    protected abstract CholeskyResult decomposeLower();
 
     public double[] _getVV() {
         return vv;

--- a/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyInner.java
+++ b/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyInner.java
@@ -18,8 +18,6 @@
 
 package mikera.matrixx.algo.decompose.chol.impl;
 
-import mikera.matrixx.algo.decompose.chol.ICholesky;
-
 /**
  * <p>
  * This implementation of a Cholesky decomposition using the inner-product form.
@@ -36,7 +34,7 @@ public class CholeskyInner extends CholeskyCommon {
     }
 
     @Override
-    protected ICholesky decomposeLower() {
+    protected CholeskyResult decomposeLower() {
         double el_ii;
         double div_el_ii=0;
 
@@ -74,6 +72,6 @@ public class CholeskyInner extends CholeskyCommon {
             }
         }
 
-        return this;
+        return new CholeskyResult(T);
     }
 }

--- a/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyLDU.java
+++ b/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyLDU.java
@@ -20,7 +20,6 @@ package mikera.matrixx.algo.decompose.chol.impl;
 
 import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrix;
-import mikera.matrixx.algo.decompose.chol.ICholeskyLDU;
 import mikera.matrixx.impl.ADiagonalMatrix;
 import mikera.matrixx.impl.DiagonalMatrix;
 
@@ -42,10 +41,9 @@ import mikera.matrixx.impl.DiagonalMatrix;
  *
  * @author Peter Abeles
  */
-public class CholeskyLDU implements ICholeskyLDU {
+public class CholeskyLDU {
 
     // it can decompose a matrix up to this width
-    private int maxWidth;
     // width and height of the matrix
     private int n;
 
@@ -59,20 +57,6 @@ public class CholeskyLDU implements ICholeskyLDU {
     // tempoary variable used by various functions
     double vv[];
 
-    public void setExpectedMaxSize( int numRows , int numCols ) {
-        if( numRows != numCols ) {
-            throw new IllegalArgumentException("Can only decompose square matrices");
-        }
-
-        this.maxWidth = numRows;
-
-//        this.L = Matrix.create(maxWidth,maxWidth);
-//        this.el = L.data;
-
-        this.vv = new double[maxWidth];
-        this.d = new double[maxWidth];
-    }
-
     /**
      * <p>
      * Performs Choleksy decomposition on the provided matrix.
@@ -80,20 +64,19 @@ public class CholeskyLDU implements ICholeskyLDU {
      *
      * <p>
      * If the matrix is not positive definite then this function will return
-     * false since it can't complete its computations.  Not all errors will be
+     * null since it can't complete its computations.  Not all errors will be
      * found.
      * </p>
      * @param mat A symetric n by n positive definite matrix.
-     * @return True if it was able to finish the decomposition.
+     * @return CholeskyResult if decomposition is successful, null otherwise.
      */
-    public ICholeskyLDU decompose( AMatrix mat ) {
-        if( mat.rowCount() > maxWidth ) {
-            setExpectedMaxSize(mat.rowCount(),mat.columnCount());
-        } else if( mat.rowCount() != mat.columnCount() ) {
+    public CholeskyResult decompose( AMatrix mat ) {
+        if( mat.rowCount() != mat.columnCount() ) {
             throw new RuntimeException("Can only decompose square matrices");
         }
         n = mat.rowCount();
-
+        this.vv = new double[n];
+        this.d = new double[n];
         L = mat.toMatrix();
         this.el = L.data;
 
@@ -126,34 +109,10 @@ public class CholeskyLDU implements ICholeskyLDU {
             }
         }
 
-        return this;
-    }
-
-    /**
-     * Diagonal D matrix.
-     *
-     * @return diagonal matrix D
-     */
-    public ADiagonalMatrix getD() {
-        return DiagonalMatrix.create(d);
-    }
-
-    /**
-     * Returns L matrix from the decomposition.<br>
-     * L*D*L<sup>T</sup>=A
-     *
-     * @return A lower triangular matrix.
-     */
-    public AMatrix getL() {
-        return L;
+        return new CholeskyResult(L, DiagonalMatrix.create(d), L.getTranspose());
     }
 
     public double[] _getVV() {
         return vv;
     }
-
-	@Override
-	public AMatrix getU() {
-		return L.getTranspose();
-	}
 }

--- a/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyResult.java
+++ b/src/main/java/mikera/matrixx/algo/decompose/chol/impl/CholeskyResult.java
@@ -21,16 +21,34 @@ public class CholeskyResult implements ICholeskyLDU {
 		this.U = U;
 	}
 
+	/**
+	 * <p>
+	 * Returns the lower triangular matrix from the decomposition.
+	 * </p>
+	 * @return A lower triangular matrix.
+	 */
 	@Override
 	public AMatrix getL() {
 		return L;
 	}
 
+	/**
+	 * <p>
+	 * Returns the upper triangular matrix from the decomposition.
+	 * </p>
+	 * @return An upper triangular matrix.
+	 */
 	@Override
 	public AMatrix getU() {
 		return U;
 	}
 
+	/**
+	 * <p>
+	 * Returns the diagonal matrix from the decomposition.
+	 * </p>
+	 * @return A diagonal matrix.
+	 */
 	@Override
 	public ADiagonalMatrix getD() {
 		return D;

--- a/src/main/java/mikera/matrixx/algo/solve/chol/CholeskyLDUSolver.java
+++ b/src/main/java/mikera/matrixx/algo/solve/chol/CholeskyLDUSolver.java
@@ -22,6 +22,7 @@ import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrix;
 import mikera.matrixx.algo.decompose.TriangularSolver;
 import mikera.matrixx.algo.decompose.chol.impl.CholeskyLDU;
+import mikera.matrixx.algo.decompose.chol.impl.CholeskyResult;
 
 /**
  * @author Peter Abeles
@@ -33,6 +34,8 @@ public class CholeskyLDUSolver {
     protected int numCols;
 
     private CholeskyLDU decomp;
+    private CholeskyResult ans;
+    
     private int n;
     private double vv[];
     private double el[];
@@ -53,11 +56,12 @@ public class CholeskyLDUSolver {
         this.numRows = A.rowCount();
         this.numCols = A.columnCount();
 
-        if( decomp.decompose(A) != null ){
+        ans = decomp.decompose(A);
+        if( ans != null ){
             n = A.columnCount();
             vv = decomp._getVV();
-            el = decomp.getL().toMatrix().data;
-            d = decomp.getD().getLeadingDiagonal().toDoubleArray();
+            el = ans.getL().toMatrix().data;
+            d = ans.getD().getLeadingDiagonal().toDoubleArray();
             return true;
         } else {
             return false;
@@ -65,7 +69,7 @@ public class CholeskyLDUSolver {
     }
 
     public double quality() {
-        return Math.abs(diagProd(decomp.getL()));
+        return Math.abs(diagProd(ans.getL()));
     }
 
     private double diagProd(AMatrix m) {

--- a/src/main/java/mikera/matrixx/algo/solve/chol/CholeskySolver.java
+++ b/src/main/java/mikera/matrixx/algo/solve/chol/CholeskySolver.java
@@ -21,6 +21,7 @@ package mikera.matrixx.algo.solve.chol;
 import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrix;
 import mikera.matrixx.algo.decompose.chol.impl.CholeskyCommon;
+import mikera.matrixx.algo.decompose.chol.impl.CholeskyResult;
 import mikera.matrixx.algo.decompose.TriangularSolver;
 
 
@@ -33,10 +34,11 @@ public class CholeskySolver {
     protected int numRows;
     protected int numCols;
     
-    CholeskyCommon decomp;
-    int n;
-    double vv[];
-    double t[];
+    private CholeskyCommon decomp;
+    private CholeskyResult ans;
+    private int n;
+    private double vv[];
+    private double t[];
 
     public CholeskySolver( CholeskyCommon decomp ) {
         this.decomp = decomp;
@@ -50,11 +52,12 @@ public class CholeskySolver {
         this.A = Matrix.create(_A);
         this.numRows = A.rowCount();
         this.numCols = A.columnCount();
-
-        if( decomp.decompose(A) != null ){
+        
+        ans = decomp.decompose(A);
+        if( ans != null ){
             n = A.columnCount();
             vv = decomp._getVV();
-            t = decomp.getL().toMatrix().data;
+            t = ans.getL().toMatrix().data;
             return true;
         } else {
             return false;
@@ -68,7 +71,7 @@ public class CholeskySolver {
 //    }
 
     public double quality() {
-        return qualityTriangular(decomp.getL().toMatrix());
+        return qualityTriangular(ans.getL().toMatrix());
     }
     
     /**

--- a/src/test/java/mikera/matrixx/algo/decompose/chol/impl/GenericCholTests.java
+++ b/src/test/java/mikera/matrixx/algo/decompose/chol/impl/GenericCholTests.java
@@ -54,8 +54,8 @@ public abstract class GenericCholTests {
         Matrix L = Matrix.create(dataL);
 
         CholeskyCommon cholesky = create();
-        ICholesky ans;
-        assertNotNull(ans = cholesky.decompose(A));
+        CholeskyResult ans = cholesky.decompose(A);
+        assertNotNull(ans);
 
         Matrix foundL = ans.getL().toMatrix();
 
@@ -78,9 +78,9 @@ public abstract class GenericCholTests {
         Matrix R = Matrix.create(dataR);
 
         CholeskyCommon cholesky = create();
-        
-        assertNotNull(cholesky.decompose(A));
-        Matrix foundR = cholesky.getU().toMatrix();
+        CholeskyResult ans = cholesky.decompose(A);
+        assertNotNull(ans);
+        Matrix foundR = ans.getU().toMatrix();
 
         assertArrayEquals(R.getElements(),foundR.getElements(),1e-8);
     }

--- a/src/test/java/mikera/matrixx/algo/decompose/chol/impl/TestCholLDU.java
+++ b/src/test/java/mikera/matrixx/algo/decompose/chol/impl/TestCholLDU.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertNull;
 import java.util.Random;
 
 import mikera.matrixx.Matrix;
-import mikera.matrixx.algo.decompose.chol.ICholeskyLDU;
 
 import org.junit.Test;
 
@@ -52,7 +51,7 @@ public class TestCholLDU {
         double D[] = new double[]{1,3,7};
 
         CholeskyLDU cholesky = new CholeskyLDU();
-        ICholeskyLDU ans = cholesky.decompose(A);
+        CholeskyResult ans = cholesky.decompose(A);
         assertNotNull(ans);
 
         Matrix foundL = ans.getL().toMatrix();


### PR DESCRIPTION
- Removed `getL`, `getU` and `getD` methods from `CholeskyCommon` and `CholeskyLDU`.
- `decompose` methods in `CholeskyCommon` and `CholeskyLDU` return `CholeskyResult`
- Removed `setMaxEstimatedSize` method from all classes in `chol.impl` package
