### PR TITLE
Product of dense matrix with sparse matrix can be dense.

### DIFF
--- a/src/main/java/mikera/matrixx/impl/SparseRowMatrix.java
+++ b/src/main/java/mikera/matrixx/impl/SparseRowMatrix.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import mikera.arrayz.ISparse;
 import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrixx;
+import mikera.matrixx.Matrix;
 import mikera.vectorz.AVector;
 import mikera.vectorz.Op;
 import mikera.vectorz.Vector;
@@ -274,11 +275,11 @@ public class SparseRowMatrix extends ASparseRCMatrix implements ISparse,
 		if (a instanceof SparseColumnMatrix) {
 			return innerProduct((SparseColumnMatrix) a);
 		}
-		AMatrix r = Matrixx.createSparse(rows, a.columnCount());
+		AMatrix r = Matrix.create(rows, a.columnCount());
 
 		for (Entry<Integer, AVector> eRow : data.entrySet()) {
 			int i = eRow.getKey();
-			r.replaceRow(i,getRow(i).innerProduct(a));
+			r.setRow(i,getRow(i).innerProduct(a));
 		}
 		return r;
 	}


### PR DESCRIPTION
Product of dense matrix with sparse matrix cannot be created with createSparse().  With probability 1 such products are dense (e.g. dense x identity).

Switched to use Matrix here, and it's safe to use setRow instead of replaceRow since the row being "replaced" has just been created.
