### PR TITLE
Speed up and OOB fix

### DIFF
--- a/src/main/java/mikera/vectorz/impl/SparseIndexedVector.java
+++ b/src/main/java/mikera/vectorz/impl/SparseIndexedVector.java
@@ -161,6 +161,9 @@ public class SparseIndexedVector extends ASparseIndexedVector {
 	
 	@Override
 	public void add(ASparseVector v) {
+        if (v instanceof ZeroVector) {
+            return;
+        }
 		includeIndices(v);	
 		for (int i=0; i<data.length; i++) {
 			data[i]+=v.unsafeGet(index.get(i));
@@ -489,12 +492,13 @@ public class SparseIndexedVector extends ASparseIndexedVector {
 		double[] data=this.data;
 		double[] ndata=new double[nl];
 		int si=0;
+        
 		for (int i=0; i<nl; i++) {
+            if (si>=data.length) break;
 			int z=index.data[si];
 			if (z==nixs[i]) {
 				ndata[i]=data[si];
 				si++; 
-				if (si>=data.length) break;
 			}
 		}
 		this.data=ndata;

--- a/src/test/java/mikera/vectorz/TestSparseVectors.java
+++ b/src/test/java/mikera/vectorz/TestSparseVectors.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import static org.junit.Assert.*;
 import mikera.vectorz.impl.SparseHashedVector;
 import mikera.vectorz.impl.SparseIndexedVector;
+import mikera.vectorz.impl.ZeroVector;
 
 import org.junit.Test;
 
@@ -31,6 +32,14 @@ public class TestSparseVectors {
 		assertEquals(1.0,v.elementSum(),0.0);
 		assertEquals(1,v.nonZeroCount());
         assertTrue(Arrays.equals(new int[]{1},v.nonZeroIndices()));
-		
+
+        SparseIndexedVector w=v.clone();
+        v.add(ZeroVector.create(10));
+        assertEquals(w, v);
+
+        SparseIndexedVector empty=SparseIndexedVector.createLength(3);
+        SparseIndexedVector nonEmpty=SparseIndexedVector.create(Vector.of(1,0,2));
+        empty.add(nonEmpty);
+        assertEquals(Vector.of(1,0,2), empty);
 	}
 }


### PR DESCRIPTION
Added a check to SparseIndexedVector#add(ASparseVector) for ZeroVector, skips iterating over values if argument is a ZeroVector.

Fixed an OutOfBounds error in SparseIndexedVector#includeIndices when the instance was empty.
