### PR TITLE
Integer overflow when finding index position

### DIFF
--- a/src/main/java/mikera/vectorz/util/IntArrays.java
+++ b/src/main/java/mikera/vectorz/util/IntArrays.java
@@ -223,7 +223,7 @@ public class IntArrays {
 		}
 		
 		while ((min+10)<max) {
-			int mid=min+((max-min)*(x-lx))/((hx-lx)*2); // best estimate of position
+            int mid = (int)((long)min+(((long)(max-min))*((long)(x-lx)))/(((long)(hx-lx))*2)); // best estimate of position
 			int mx=data[mid];
 			if (x==mx) return mid;
 			if (x<mx) {

--- a/src/main/java/mikera/vectorz/util/IntArrays.java
+++ b/src/main/java/mikera/vectorz/util/IntArrays.java
@@ -223,7 +223,7 @@ public class IntArrays {
 		}
 		
 		while ((min+10)<max) {
-            int mid = (int)((long)min+(((long)(max-min))*((long)(x-lx)))/(((long)(hx-lx))*2)); // best estimate of position
+			int mid = (int)((long)min+(((long)(max-min))*((long)(x-lx)))/(((long)(hx-lx))*2)); // best estimate of position
 			int mx=data[mid];
 			if (x==mx) return mid;
 			if (x<mx) {

--- a/src/test/java/mikera/vectorz/util/TestIntArrays.java
+++ b/src/test/java/mikera/vectorz/util/TestIntArrays.java
@@ -45,4 +45,14 @@ public class TestIntArrays {
 		
 		assertArrayEquals(zs,IntArrays.intersectSorted(xs, ys));
 	}
+
+    @Test public void testIndexPositionOverflow() {
+        int[] xs=new int[46342];
+        for (int i=0; i<xs.length; i++) {
+            xs[i]=i;
+        }
+
+        assertEquals(46340,IntArrays.indexPosition(xs,46340));
+    }
+    
 }


### PR DESCRIPTION
There was an integer overflow in calculating the midpoint when searching for an index position. Pull request includes a fix and a test.