### PR TITLE
Faster conversion between row and column representations of sparse matrices

### DIFF
--- a/src/main/java/mikera/matrixx/impl/ASparseRCMatrix.java
+++ b/src/main/java/mikera/matrixx/impl/ASparseRCMatrix.java
@@ -1,14 +1,17 @@
 package mikera.matrixx.impl;
 
-// import java.util.HashMap;
-// import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
 
 import mikera.matrixx.AMatrix;
 import mikera.matrixx.Matrix;
 import mikera.vectorz.AVector;
 import mikera.vectorz.Op;
 import mikera.vectorz.Vector;
+import mikera.vectorz.Vectorz;
 import mikera.vectorz.impl.RepeatedElementVector;
+import mikera.vectorz.impl.SparseIndexedVector;
 import mikera.vectorz.util.VectorzException;
 
 /**
@@ -225,6 +228,68 @@ public abstract class ASparseRCMatrix extends ARectangularMatrix {
 	public void copyColumnTo(int j, double[] dest, int destOffset) {
 		getColumn(j).copyTo(dest, destOffset);
 	}
+
+    // Rotate the AVectors in data[]. Transforms data that was represented as
+    // row vectors to now be represented as column vectors and vice versa.
+    public List<AVector> getRotatedData(int outerLen, int innerLen) {
+        int numVecs = outerLen;
+        int numElems = innerLen;
+        ArrayList<ArrayList<Integer>> rotIndexList = new ArrayList<ArrayList<Integer>>(numElems);
+        ArrayList<ArrayList<Double>> rotValueList = new ArrayList<ArrayList<Double>>(numElems);
+        ArrayList<AVector> rotList = new ArrayList<AVector>(numElems);
+        AVector emptyRotVec = Vectorz.createZeroVector(numVecs);
+
+        for (int i = 0; i < numElems; i++) {
+            rotIndexList.add(new ArrayList<Integer>());
+            rotValueList.add(new ArrayList<Double>());
+        }
+
+        for (int i = 0; i < numVecs; i++) {
+            AVector vec = unsafeGetVector(i);
+            if (null != vec) {
+                int[] nonZeroIdxs = vec.nonZeroIndices();
+                Vector nonZeroVals = null;
+                if (vec instanceof SparseIndexedVector) {
+                    nonZeroVals = ((SparseIndexedVector)vec).nonSparseValues();
+                } else {
+                    // TODO: AVector@nonZeroValues() could be sped up by using nonZeroIndices.
+                    nonZeroVals = Vector.wrap(vec.nonZeroValues());
+                }
+
+                assert(nonZeroIdxs.length == nonZeroVals.length());
+
+                for (int j = 0; j < nonZeroIdxs.length; j++) {
+                    int idx = nonZeroIdxs[j];
+                    double val = nonZeroVals.unsafeGet(j);
+
+                    rotIndexList.get(idx).add(i);
+                    rotValueList.get(idx).add(val);
+                }
+            }
+        }
+
+        for (int i = 0; i < numElems; i++) {
+            ArrayList<Integer> rotIndex = rotIndexList.get(i);
+            ArrayList<Double> rotValue = rotValueList.get(i);
+            AVector rotVec = emptyRotVec;
+
+            if (!rotIndex.isEmpty()) {
+                int size = rotIndex.size();
+                int[] indices = new int[size];
+                double[] vals = new double[size];
+
+                for (int j = 0; j < size; j++) {
+                    indices[j] = rotIndex.get(j);
+                    vals[j] = rotValue.get(j);
+                }
+
+                rotVec = SparseIndexedVector.wrap(numVecs, indices, vals);
+            }
+            rotList.add(rotVec);
+        }
+
+        return rotList;
+    }
 	
 	@Override
 	public double elementSum() {

--- a/src/main/java/mikera/matrixx/impl/SparseColumnMatrix.java
+++ b/src/main/java/mikera/matrixx/impl/SparseColumnMatrix.java
@@ -186,27 +186,13 @@ public class SparseColumnMatrix extends ASparseRCMatrix implements ISparse, IFas
 
     @Override
     public List<AVector> getRows() {
-        return toSparseRowMatrix().getRows();
+        return getRotatedData(cols, rows);
     }
     
     public SparseRowMatrix toSparseRowMatrix() {
-        SparseRowMatrix rm=SparseRowMatrix.create(rows, cols);
-
-        for (int j = 0; j < cols; j++) {
-            AVector colVec = unsafeGetVector(j);
-            if (colVec!=null) {
-                Index nonSparseRows = colVec.nonSparseIndex();
-                int n=nonSparseRows.length();
-                for (int k = 0; k < n; k++) {
-                    int i = nonSparseRows.unsafeGet(k);
-                    double v=colVec.unsafeGet(i);
-                    if (v!=0.0) {
-                    	rm.unsafeSet(i,j, v);
-                    }
-                } 
-            }
-        }
-        return rm;    	
+        AVector[] rowVecs = getRows().toArray(new AVector[rows]);
+        SparseRowMatrix rm = SparseRowMatrix.create(rowVecs, rows, cols);
+        return rm;
     }
     
 	private AVector ensureMutableColumn(int i) {

--- a/src/main/java/mikera/matrixx/impl/SparseRowMatrix.java
+++ b/src/main/java/mikera/matrixx/impl/SparseRowMatrix.java
@@ -3,13 +3,6 @@ package mikera.matrixx.impl;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
-// import java.util.HashMap;
-// import java.util.HashSet;
-// import java.util.Map;
-// import java.util.Map.Entry;
-
-
-
 
 import mikera.arrayz.INDArray;
 import mikera.arrayz.ISparse;
@@ -229,26 +222,13 @@ public class SparseRowMatrix extends ASparseRCMatrix implements ISparse, IFastRo
 
     @Override
     public List<AVector> getColumns() {
-        return toSparseColumnMatrix().getColumns();
+        return getRotatedData(rows, cols);
     }
     
     public SparseColumnMatrix toSparseColumnMatrix() {
-        SparseColumnMatrix cm=SparseColumnMatrix.create(rows,cols);
-        for (int i = 0; i < rows; i++) {
-            AVector rowVec = unsafeGetVector(i);
-            if (null != rowVec) {
-                Index nonSparseCols = rowVec.nonSparseIndex();
-                int n=nonSparseCols.length();
-                for (int k = 0; k < n; k++) {
-                    int j = nonSparseCols.unsafeGet(k);
-                    double v=rowVec.unsafeGet(j);
-                    if (v!=0.0) {
-                    	cm.unsafeSet(i,j, v);
-                    }
-                }
-            }
-        }
-        return cm;    	
+        AVector[] colVecs = getColumns().toArray(new AVector[cols]);
+        SparseColumnMatrix cm = SparseColumnMatrix.create(colVecs, rows, cols);
+        return cm;
     }
     
 	@Override

--- a/src/test/java/mikera/matrixx/impl/TestSparseColumnMatrix.java
+++ b/src/test/java/mikera/matrixx/impl/TestSparseColumnMatrix.java
@@ -43,9 +43,9 @@ public class TestSparseColumnMatrix {
     }
 
     @Test public void testGetSlices() {
-        SparseRowMatrix m = SparseRowMatrix.create(Matrix.create(Vector.of(1,0,2),
-                                                                 Vector.of(0,0,0),
-                                                                 Vector.of(3,0,4)));
+        SparseColumnMatrix m = SparseColumnMatrix.create(Matrix.create(Vector.of(1,0,2),
+                                                                       Vector.of(0,0,0),
+                                                                       Vector.of(3,0,4)));
 
         List<AVector> rows = m.getSlices();
         assertEquals(3, rows.size());
@@ -54,6 +54,17 @@ public class TestSparseColumnMatrix {
         assertEquals(Vector.of(3,0,4), rows.get(2));
     }
 
+    @Test public void testGetRows() {
+        SparseColumnMatrix m = SparseColumnMatrix.create(new AVector[] {Vector.of(1,2),
+                                                                        Vector.of(0,0),
+                                                                        Vector.of(3,4)},
+            2, 3);
+        
+        List<AVector> rows = m.getRows();
+        assertEquals(2, rows.size());
+        assertEquals(Vector.of(1,0,3), rows.get(0));
+        assertEquals(Vector.of(2,0,4), rows.get(1));
+    }
 	
 	@Test public void testOps() {
 		SparseColumnMatrix m=SparseColumnMatrix.create(Vector.of(0,1,2),AxisVector.create(2, 3));


### PR DESCRIPTION
A similar change was included in one of the earlier batches of sparse matrix updates but it seemed to have been lost in the shuffle. For a simple benchmark it provides a ~5x speedup.

This change improves performance when converting between row and column representations of sparse matrices. The previous version of getColumns/getRows involved converting a `SparseRowMatrix` to a `SparseColumnMatrix` and then calling getColumns or getRows on the new matrix. However, the conversion between matrices was inefficient where the `unsafeSet` method was being called on the new matrix to transfer values over which includes O(lg n) operations for every call.

I ran a simple benchmark with Criterium:

```
WARNING: Final GC required 1.0204683913295038 % of runtime
Evaluation count : 9120 in 60 samples of 152 calls.
             Execution time mean : 6.880668 ms
    Execution time std-deviation : 192.238086 µs
   Execution time lower quantile : 6.624899 ms ( 2.5%)
   Execution time upper quantile : 7.242259 ms (97.5%)
                   Overhead used : 2.279281 ns

Found 1 outliers in 60 samples (1.6667 %)
	low-severe	 1 (1.6667 %)
 Variance from outliers : 15.7399 % Variance is moderately inflated by outliers

WARNING: Final GC required 1.601230154441423 % of runtime
Evaluation count : 1680 in 60 samples of 28 calls.
             Execution time mean : 35.976748 ms
    Execution time std-deviation : 853.381594 µs
   Execution time lower quantile : 34.495605 ms ( 2.5%)
   Execution time upper quantile : 37.729319 ms (97.5%)
                   Overhead used : 2.279281 ns

Found 1 outliers in 60 samples (1.6667 %)
	low-severe	 1 (1.6667 %)
 Variance from outliers : 11.0367 % Variance is moderately inflated by outliers
```

The code used to run the benchmarks:
```
  (require '[criterium.core :as crit])
  (require '[clojure.core.matrix :as mx])
  (require '[munge.matrix :as mmx])
  (import '[mikera.matrixx.impl SparseColumnMatrix])
  
  (mx/set-current-implementation :vectorz)

  (defn random-cells [num-cells max-index]
    (->> (map vector (repeatedly #(-> (rand) (* max-index) Math/floor int)) (repeatedly rand))
         (take num-cells)))

  
  (def m (mmx/sparse-matrix 1000 1000 (repeatedly 1000 #(random-cells 100 1000))))

  (crit/bench (.toSparseColumnMatrixAlt m)
  (crit/bench (.toSparseColumnMatrix m))
```

That code isn't directly runnable for you but is provided for reference in case you want to verify the performance gain.