### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/src/main/java/mikera/arrayz/Arrayz.java
+++ b/src/main/java/mikera/arrayz/Arrayz.java
@@ -37,6 +37,9 @@ import us.bpsm.edn.parser.Parsers;
  * @author Mike
  */
 public class Arrayz {
+
+	private Arrayz(){}
+
 	/**
 	 * Creates an array from the given data
 	 * 

--- a/src/main/java/mikera/indexz/Indexz.java
+++ b/src/main/java/mikera/indexz/Indexz.java
@@ -12,6 +12,8 @@ import mikera.util.Rand;
  *
  */
 public class Indexz {
+
+	private Indexz(){}
 	
 	public static Index create(List<Integer> data) {
 		int length=data.size();

--- a/src/main/java/mikera/matrixx/algo/Definite.java
+++ b/src/main/java/mikera/matrixx/algo/Definite.java
@@ -8,6 +8,8 @@ import mikera.vectorz.Vector2;
 
 public class Definite {
 
+	private Definite(){}
+
 	/**
 	 * Tests whether a symmetric matrix is positive definite
 	 * 

--- a/src/main/java/mikera/matrixx/algo/Determinant.java
+++ b/src/main/java/mikera/matrixx/algo/Determinant.java
@@ -17,6 +17,7 @@ import mikera.vectorz.util.IntArrays;
  *
  */
 public class Determinant {
+	private Determinant(){}
 	
 	/**
 	 * Calculate the determinant of an AMatrix.

--- a/src/main/java/mikera/matrixx/algo/Inverse.java
+++ b/src/main/java/mikera/matrixx/algo/Inverse.java
@@ -9,6 +9,8 @@ import mikera.vectorz.util.ErrorMessages;
 
 public final class Inverse {
 
+	private Inverse(){}
+
 	/**
 	 * Computes the inverse of an arbitrary square Matrix.
 	 * 

--- a/src/main/java/mikera/matrixx/algo/Multiplications.java
+++ b/src/main/java/mikera/matrixx/algo/Multiplications.java
@@ -7,6 +7,9 @@ import mikera.vectorz.util.DoubleArrays;
 import mikera.vectorz.util.ErrorMessages;
 
 public class Multiplications {
+
+	private Multiplications(){}
+
 	// target number of elements in working set group
 	// aim for around 200kb => fits comfortably in L2 cache in modern machines
 	protected static final int WORKING_SET_TARGET=8192;

--- a/src/main/java/mikera/matrixx/algo/Rank.java
+++ b/src/main/java/mikera/matrixx/algo/Rank.java
@@ -6,6 +6,8 @@ import mikera.matrixx.decompose.SVD;
 import mikera.vectorz.AVector;
 
 public class Rank {
+
+	private Rank(){}
 	
 	private static double DEFAULT_THRESHOLD = 2.220446e-15;
 	

--- a/src/main/java/mikera/matrixx/algo/impl/Constants.java
+++ b/src/main/java/mikera/matrixx/algo/impl/Constants.java
@@ -2,6 +2,8 @@ package mikera.matrixx.algo.impl;
 
 public class Constants {
 
+	private Constants(){}
+
 	public static final double EPS;
 	
 	// Determine the machine epsilon

--- a/src/main/java/mikera/matrixx/decompose/Bidiagonal.java
+++ b/src/main/java/mikera/matrixx/decompose/Bidiagonal.java
@@ -10,6 +10,8 @@ import mikera.matrixx.decompose.impl.bidiagonal.BidiagonalRow;
  *
  */
 public class Bidiagonal {
+
+	private Bidiagonal(){}
 	
 	// TODO: needs docs for API functions
 

--- a/src/main/java/mikera/matrixx/decompose/Cholesky.java
+++ b/src/main/java/mikera/matrixx/decompose/Cholesky.java
@@ -18,6 +18,8 @@ import mikera.matrixx.AMatrix;
  */
 public class Cholesky {
 	// TODO: refactor to use best available Cholesky decomposition algorithm for different matrix types and sizes
+
+	private Cholesky(){}
 	
 	/**
 	 * Decompose a Matrix according the the Cholesky decomposition A = L.L*

--- a/src/main/java/mikera/matrixx/decompose/Eigen.java
+++ b/src/main/java/mikera/matrixx/decompose/Eigen.java
@@ -4,6 +4,8 @@ import mikera.matrixx.AMatrix;
 import mikera.matrixx.decompose.impl.eigen.SymmetricQRAlgorithmDecomposition;
 
 public class Eigen {
+
+    private Eigen(){}
     
     /**
      * <p>

--- a/src/main/java/mikera/matrixx/decompose/Hessenberg.java
+++ b/src/main/java/mikera/matrixx/decompose/Hessenberg.java
@@ -8,6 +8,8 @@ import mikera.matrixx.decompose.impl.hessenberg.HessenbergSimilarDecomposition;
  * Public API class for Hessenberg decomposition
  */
 public class Hessenberg {
+
+	private Hessenberg(){}
 	
 	/**
 	 * <p>

--- a/src/main/java/mikera/matrixx/decompose/LUP.java
+++ b/src/main/java/mikera/matrixx/decompose/LUP.java
@@ -6,6 +6,8 @@ import mikera.matrixx.decompose.impl.lu.AltLU;
 public class LUP {
 	
 	// TODO: fuller documentation for LUP properties
+
+	private LUP(){}
 	
 	/**
 	 * This performs LU decomposition on the given matrix and returns the result as a ILUPResult object

--- a/src/main/java/mikera/matrixx/decompose/QR.java
+++ b/src/main/java/mikera/matrixx/decompose/QR.java
@@ -40,6 +40,8 @@ import mikera.matrixx.decompose.impl.qr.HouseholderQR;
  */
 public class QR {
 
+	private QR(){}
+
     /**
      * Computes the QR factorisation of a matrix A such that:
      * 

--- a/src/main/java/mikera/matrixx/decompose/SVD.java
+++ b/src/main/java/mikera/matrixx/decompose/SVD.java
@@ -13,6 +13,8 @@ import mikera.matrixx.decompose.impl.svd.SvdImplicitQr;
  *
  */
 public class SVD {
+
+	private SVD(){}
 	
 	/**
 	 * Computes the Singular Value Decomposition of a matrix, which is the decomposition

--- a/src/main/java/mikera/matrixx/decompose/impl/chol/SimpleCholesky.java
+++ b/src/main/java/mikera/matrixx/decompose/impl/chol/SimpleCholesky.java
@@ -22,6 +22,8 @@ import mikera.util.Maths;
  */
 public class SimpleCholesky {
 
+	private SimpleCholesky(){}
+
 	/**
 	 * Decompose a matrix according the the Cholesky decomposition A = L.L*
 	 * 

--- a/src/main/java/mikera/matrixx/decompose/impl/lu/DecomposeLUP.java
+++ b/src/main/java/mikera/matrixx/decompose/impl/lu/DecomposeLUP.java
@@ -7,6 +7,8 @@ import mikera.vectorz.util.ErrorMessages;
 
 public class DecomposeLUP {
 
+	private DecomposeLUP(){}
+
 	public static Matrix createLUPInverse(AMatrix m) {
 		if (!m.isSquare()) { throw new IllegalArgumentException(
 				"Matrix must be square for inverse!"); }

--- a/src/main/java/mikera/matrixx/decompose/impl/lu/SimpleLUP.java
+++ b/src/main/java/mikera/matrixx/decompose/impl/lu/SimpleLUP.java
@@ -34,6 +34,9 @@ import mikera.matrixx.impl.PermutationMatrix;
  *
  */
 public class SimpleLUP {
+
+	private SimpleLUP(){}
+
 	public static ILUPResult decompose(AMatrix matrix) {
 		return decomposeLUPInternal(Matrix.create(matrix));
 	}

--- a/src/main/java/mikera/matrixx/decompose/impl/qr/QRHelperFunctions.java
+++ b/src/main/java/mikera/matrixx/decompose/impl/qr/QRHelperFunctions.java
@@ -43,6 +43,8 @@ import mikera.matrixx.Matrix;
  */
 public class QRHelperFunctions {
 
+    private QRHelperFunctions(){}
+
     public static double findMax( double[] u, int startU , int length ) {
         double max = -1;
 

--- a/src/main/java/mikera/matrixx/decompose/impl/svd/ThinSVD.java
+++ b/src/main/java/mikera/matrixx/decompose/impl/svd/ThinSVD.java
@@ -34,6 +34,8 @@ import mikera.vectorz.Vector;
  */
 public class ThinSVD {
 
+	private ThinSVD(){}
+
 	public static ISVDResult decompose(AMatrix a) {
 		return decompose(Matrix.create(a));
 	}

--- a/src/main/java/mikera/matrixx/solve/Linear.java
+++ b/src/main/java/mikera/matrixx/solve/Linear.java
@@ -15,6 +15,8 @@ import mikera.vectorz.AVector;
  *
  */
 public class Linear {
+
+	private Linear(){}
     
     /**
      * 

--- a/src/main/java/mikera/matrixx/solve/impl/TriangularSolver.java
+++ b/src/main/java/mikera/matrixx/solve/impl/TriangularSolver.java
@@ -36,6 +36,8 @@ package mikera.matrixx.solve.impl;
  */
 public class TriangularSolver {
 
+    private TriangularSolver(){}
+
     /**
      * <p>
      * Inverts a square lower triangular matrix:  L = L<sup>-1</sup>

--- a/src/main/java/mikera/vectorz/Ops.java
+++ b/src/main/java/mikera/vectorz/Ops.java
@@ -37,6 +37,9 @@ import mikera.vectorz.ops.Tanh;
  * 
  */
 public final class Ops {
+
+	private Ops(){}
+
 	public static final Op ABS = Absolute.INSTANCE;
 	public static final Op SIGNUM = Signum.INSTANCE;
 	public static final Op STOCHASTIC_BINARY = StochasticBinary.INSTANCE;

--- a/src/main/java/mikera/vectorz/Quaternions.java
+++ b/src/main/java/mikera/vectorz/Quaternions.java
@@ -11,6 +11,9 @@ package mikera.vectorz;
  *
  */
 public class Quaternions {
+
+	private Quaternions(){}
+
 	/** 
 	 * Computes the conjugate of a quaternion
 	 * 

--- a/src/main/java/mikera/vectorz/Tools.java
+++ b/src/main/java/mikera/vectorz/Tools.java
@@ -5,6 +5,9 @@ import java.util.Iterator;
 import java.util.List;
 
 public final class Tools {
+
+	private Tools(){}
+
 	public static void debugBreak(Object o) {
 		o.toString();
 	}

--- a/src/main/java/mikera/vectorz/Vectorz.java
+++ b/src/main/java/mikera/vectorz/Vectorz.java
@@ -25,6 +25,9 @@ import us.bpsm.edn.parser.Parser;
 import us.bpsm.edn.parser.Parsers;
 
 public class Vectorz {
+
+	private Vectorz(){}
+
 	/**
 	 * Constant tolerance used for testing double values
 	 */

--- a/src/main/java/mikera/vectorz/util/Constants.java
+++ b/src/main/java/mikera/vectorz/util/Constants.java
@@ -2,6 +2,8 @@ package mikera.vectorz.util;
 
 public class Constants {
 
+	private Constants(){}
+
 	public static final Double ZERO_DOUBLE = Double.valueOf(0.0);
 	
 	public static final long PRINT_THRESHOLD = 10000;

--- a/src/main/java/mikera/vectorz/util/DoubleArrays.java
+++ b/src/main/java/mikera/vectorz/util/DoubleArrays.java
@@ -5,6 +5,9 @@ import mikera.vectorz.Tools;
 import mikera.vectorz.ops.Logistic;
 
 public final class DoubleArrays {
+
+	private DoubleArrays(){}
+
 	public static final double[] EMPTY = new double[0];
 
 	public static final double elementSum(double[] data) {

--- a/src/main/java/mikera/vectorz/util/ErrorMessages.java
+++ b/src/main/java/mikera/vectorz/util/ErrorMessages.java
@@ -6,6 +6,9 @@ import mikera.matrixx.AMatrix;
 import mikera.vectorz.AVector;
 
 public class ErrorMessages {
+
+	private ErrorMessages(){}
+
 	private static String shape(INDArray a) {
 		return Index.of(a.getShape()).toString();
 	}

--- a/src/main/java/mikera/vectorz/util/IntArrays.java
+++ b/src/main/java/mikera/vectorz/util/IntArrays.java
@@ -7,6 +7,9 @@ import mikera.util.Rand;
 import mikera.vectorz.Tools;
 
 public class IntArrays {
+
+	private IntArrays(){}
+
 	public static final int[] EMPTY_INT_ARRAY=new int[0];
 	
 	public static int[] of(int... ints) {

--- a/src/main/java/mikera/vectorz/util/LongArrays.java
+++ b/src/main/java/mikera/vectorz/util/LongArrays.java
@@ -1,6 +1,9 @@
 package mikera.vectorz.util;
 
 public class LongArrays {
+
+	private LongArrays(){}
+
 	public static final long[] EMPTY_LONG_ARRAY=new long[0];
 	
 	public static long[] removeIndex(long[] data, int index) {

--- a/src/main/java/mikera/vectorz/util/Testing.java
+++ b/src/main/java/mikera/vectorz/util/Testing.java
@@ -14,6 +14,8 @@ import mikera.vectorz.impl.Vector0;
  */
 public class Testing {
 
+	private Testing(){}
+
 	public static AVector createTestVector(int length) {
 		return createTestVector(length,new Random());
 	} 

--- a/src/test/java/mikera/vectorz/TestingUtils.java
+++ b/src/test/java/mikera/vectorz/TestingUtils.java
@@ -4,6 +4,7 @@ import mikera.arrayz.Arrayz;
 import mikera.arrayz.INDArray;
 
 public class TestingUtils {
+	private TestingUtils(){}
 
 	public static INDArray createRandomLike(INDArray a, long seed) {
 		INDArray r=Arrayz.newArray(a.getShape());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Soso Tughushi
