### PR TITLE
mikera.matrixx.TestMatrix::testSet has inadequate loop coverage

### DIFF
--- a/src/test/java/mikera/matrixx/TestMatrix.java
+++ b/src/test/java/mikera/matrixx/TestMatrix.java
@@ -106,6 +106,15 @@ public class TestMatrix {
 	  assertEquals(m, Matrix.create(new double[][] {{5,5},{5,5}}));
 	  
   }
+
+  @Test
+  public void testSetWithMoreThanOneIteration() {
+          Matrix m=Matrix.create(new double[][] {{1,2},{3,4},{5,6},{7,8}});
+	  m.set(Vector.of(5,5,5,5));
+	  
+	  assertEquals(m, Matrix.create(new double[][] {{5,5},{5,5},{5,5},{5,5}}));
+	  
+  }
   
   @Test
   public void testIsOrthogonal() {


### PR DESCRIPTION
Currently, `mikera.matrixx.TestMatrix::testSet` only executes one iteration of the loop in method `mikera.matrixx.Matrix.set(Avector a)`. This PR adds a test `mikera.matrixx.TestMatrix::testSetWithMoreThanOneIteration()` so that it exercises the loop at least 3 times, thereby achieving better [loop coverage](http://www.bullseye.com/coverage.html#other_loop)