### PR TITLE
making the test for swap functions of the class `mikera.matrixx.Matrix` stronger

### DIFF
--- a/src/test/java/mikera/matrixx/TestMatrices.java
+++ b/src/test/java/mikera/matrixx/TestMatrices.java
@@ -156,9 +156,13 @@ public class TestMatrices {
 		AMatrix m2=m.clone();
 		m2.swapRows(0, 1);
 		assert(!m2.equals(m));
+		assertEquals(m2.getRow(0), m.getRow(1));
+		assertEquals(m2.getRow(1), m.getRow(0));
 		m2.swapRows(0, 1);
 		assert(m2.equals(m));
 		m2.swapColumns(0, 1);
+		assertEquals(m2.getColumn(0), m.getColumn(1));
+		assertEquals(m2.getColumn(1), m.getColumn(0));
 		assert(!m2.equals(m));
 		m2.swapColumns(0, 1);
 		assert(m2.equals(m));	


### PR DESCRIPTION
Currently, the method `mikera.matrixx.TestMatrices#doSwapTest` tests the function  `public void swapRows(int i, int j)` from the class `mikera.matrixx.Matrix` by:
- making a copy of the matrix
- swapping two rows in the copied matrix
- asserting the matrices are different
- swapping back the two rows
- asserting the matrices are equal.

The assertions are not strong enough to make sure that a swap operation occurred on all entries of the rows. For example, the implementation of the function could skip every other element in the swapping loop  and the test would still pass. To address that, we add assertions that check that the swapped rows are as expected.

Similarly for testing the function `public void swapColumns(int i, int j)`